### PR TITLE
Improve support for `file:` URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `path.js` with methods for normalizing paths & converting from/to `file:` URLs
+
+### Fixed
+- File operations now work with `file:` URLs or paths
+
 ## [v1.1.1] - 2023-09-29
 
 ### Added

--- a/consts.js
+++ b/consts.js
@@ -1,7 +1,12 @@
 /* eslint-env node */
+
 export const LF = '\n';
 export const CRLF = '\r\n';
 export const TAB = '\t';
+export const URL_PREFIXES = ['https:', 'http:', 'blob:', 'data:'];
+export const PATH_PREFIXES = ['file:', '/', './', '../'];
 export const ROOT = 'process' in globalThis && process.cwd instanceof Function
-	? new URL(`${process.cwd()}/`, 'file:')
+	? await import('node:url').then(({ pathToFileURL} ) => pathToFileURL(`${process.cwd()}/`))
 	: 'document' in globalThis ? new URL(document.baseURI) : null;
+
+console.log(ROOT.href);

--- a/consts.js
+++ b/consts.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+import { pathToFileURL } from 'node:url';
 
 export const LF = '\n';
 export const CRLF = '\r\n';
@@ -6,7 +7,5 @@ export const TAB = '\t';
 export const URL_PREFIXES = ['https:', 'http:', 'blob:', 'data:'];
 export const PATH_PREFIXES = ['file:', '/', './', '../'];
 export const ROOT = 'process' in globalThis && process.cwd instanceof Function
-	? await import('node:url').then(({ pathToFileURL} ) => pathToFileURL(`${process.cwd()}/`))
+	? pathToFileURL(`${process.cwd()}/`)
 	: 'document' in globalThis ? new URL(document.baseURI) : null;
-
-console.log(ROOT.href);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/npm-utils",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/npm-utils",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@shgysk8zer0/consts": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/npm-utils",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A collection of helpful functions for npm packages.",
   "type": "module",
   "main": "cjs/index.cjs",

--- a/path.js
+++ b/path.js
@@ -1,5 +1,5 @@
 import { pathToFileURL, fileURLToPath } from 'node:url';
-import { resolve, isAbsolute as isAbs } from 'node:path';
+import { resolve, isAbsolute as isAbs, dirname as dir, sep } from 'node:path';
 import { URL_PREFIXES, ROOT } from './consts.js';
 import { validateURL } from './url.js';
 
@@ -13,7 +13,6 @@ export function isAbsolute(path) {
 		return isAbs(url.pathname) && path.endsWith(url.pathname);
 	} else if (URL_PREFIXES.some(protocol => path.startsWith(protocol))) {
 		const url = new URL(path);
-		console.log({ url: url.href, path });
 		return url.href === path && isAbsolute(url.pathname);
 	} else {
 		return isAbs(path);
@@ -21,6 +20,10 @@ export function isAbsolute(path) {
 }
 
 export const isRelative = path => ! isAbsolute(path);
+
+export const dirname = path => dir(path) + '/';
+
+export const cwd = () => pathToFileURL(process.cwd() + sep);
 
 export function getFileURL(path, base = ROOT.pathname) {
 	if (path instanceof URL && path.protocol === 'file:') {

--- a/url.js
+++ b/url.js
@@ -2,12 +2,12 @@ import { ROOT } from './consts.js';
 import { isPath, isURL } from './utils.js';
 import { getFileURL } from './path.js';
 
-export function pathToURL(path, base = ROOT) {
+export function pathToURL(path, base = ROOT.pathname) {
 	if (path instanceof URL) {
 		return path;
 	} else if (isPath(base)) {
 		// Absolute paths should be relative to project root/base
-		return getFileURL(path, base);
+		return getFileURL(path.startsWith('/') ? `.${path}` : path, base);
 		/*return new URL(
 			path.startsWith('/') ? `.${path}` : path,
 			`file://${base.replace('file://', '')}`

--- a/url.js
+++ b/url.js
@@ -10,10 +10,6 @@ export function pathToURL(path, base = ROOT.pathname) {
 	} else if (isPath(path) && isPath(base)) {
 		// Absolute paths should be relative to project root/base
 		return getFileURL(path.startsWith('/') ? `.${path}` : path, base);
-		/*return new URL(
-			path.startsWith('/') ? `.${path}` : path,
-			`file://${base.replace('file://', '')}`
-		);*/
 	} else if (isURL(base) || base instanceof URL) {
 		return new URL(path, base);
 	} else {

--- a/url.js
+++ b/url.js
@@ -5,7 +5,9 @@ import { getFileURL } from './path.js';
 export function pathToURL(path, base = ROOT.pathname) {
 	if (path instanceof URL) {
 		return path;
-	} else if (isPath(base)) {
+	} else if (isURL(path)) {
+		return new URL(path);
+	} else if (isPath(path) && isPath(base)) {
 		// Absolute paths should be relative to project root/base
 		return getFileURL(path.startsWith('/') ? `.${path}` : path, base);
 		/*return new URL(

--- a/url.js
+++ b/url.js
@@ -1,15 +1,17 @@
 import { ROOT } from './consts.js';
 import { isPath, isURL } from './utils.js';
+import { getFileURL } from './path.js';
 
 export function pathToURL(path, base = ROOT) {
 	if (path instanceof URL) {
 		return path;
 	} else if (isPath(base)) {
 		// Absolute paths should be relative to project root/base
-		return new URL(
+		return getFileURL(path, base);
+		/*return new URL(
 			path.startsWith('/') ? `.${path}` : path,
 			`file://${base.replace('file://', '')}`
-		);
+		);*/
 	} else if (isURL(base) || base instanceof URL) {
 		return new URL(path, base);
 	} else {
@@ -18,10 +20,16 @@ export function pathToURL(path, base = ROOT) {
 }
 
 export function validateURL(path, base) {
-	try {
-		new URL(path, base);
+	if (path instanceof URL) {
 		return true;
-	} catch {
-		return false;
+	} else if (URL.canParse instanceof Function) {
+		return URL.canParse(path, base);
+	} else {
+		try {
+			new URL(path, base);
+			return true;
+		} catch {
+			return false;
+		}
 	}
 }

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,7 @@
-export const URL_PREFIXES = ['https:', 'http:', 'blob:', 'data:'];
-export const PATH_PREFIXES = ['file:', '/', './', '../'];
+// export const URL_PREFIXES = ['https:', 'http:', 'blob:', 'data:'];
+// export const PATH_PREFIXES = ['file:', '/', './', '../'];
 
+import { URL_PREFIXES, PATH_PREFIXES } from './consts.js';
 export const isString = str => typeof str === 'string';
 export const isObject  = thing => typeof thing === 'object'
 	&&  ! Object.is(thing, null)


### PR DESCRIPTION
**Added**
- `path.js` with methods for normalizing paths & converting from/to
`file:` URLs

**Fixed**
- File operations now work with `file:` URLs or paths

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
